### PR TITLE
Fix example in README for self-hosted instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ configuration options:
 * `email`: The email address to use as the account name when logging into the
   Bitwarden server. Required.
 * `base_url`: The URL of the Bitwarden server to use. Defaults to the official
-  server at `https://api.bitwarden.com/` if unset.
+  server at `https://api.bitwarden.com` if unset. Do not use a `/` at the end of the `base_url`.
 * `identity_url`: The URL of the Bitwarden identity server to use. If unset,
   will use the `/identity` path on the configured `base_url`, or
   `https://identity.bitwarden.com/` if no `base_url` is set.


### PR DESCRIPTION
For self-hosted servers, the `base_url` must not include a `/` at the end, because `/api` will be concatenated to it. If you do, the error message is quite vague:

```
rbw login: failed to log in to bitwarden instance: failed to parse JSON: .: EOF while parsing a value at line 1 column 0: EOF while parsing a value at line 1 column 0
```

Took me some time to read your code and figure out that the slash was the problem. I was mainly confused by the example `https://api.bitwarden.com/` given, which has a trailing slash. So I included it in my self-hosted URL.

Alternatively, you could think about concatenating the URL using some library, which would drop a `/` if necessary (I don't know Rust, so I can't help).

Thank you for creating this tool! The `pinentry` and caching of the password in the agent is exactly what is missing from the official client.